### PR TITLE
Minor typo fixes and added prefixes to all the AWS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A State Machine demonstrating Lambda orchestration with a third party applicatio
 
 ## Description
 
-This is demonstration of a State Machine with Lambda, SNS, SQS and S3. The processing Lambda generates a payload and pushes to a SQS Queue. An integration Lambda processes the payload and send a file with task token to S3 outbound folder. An Business Application processes the information and sends a success trigger to the S3 inbound folder. The integration Lambda reads the success trigger and sends a success signal to the State Machine and resumes processing. Once processing completes, the State Machine sends a Success notification to SNS Topic. If the processing Lambda fails after 3 retries the State Machine fails and a Failure notification is sent to the SNS Topic..
+This is demonstration of a State Machine with Lambda, SNS, SQS and S3. The processing Lambda generates a payload and pushes to a SQS Queue. An integration Lambda processes the payload and send a file with task token to S3 outbound folder. An Business Application processes the information and sends a success trigger to the S3 inbound folder. The integration Lambda reads the success trigger and sends a success signal to the State Machine and resumes processing. Once processing completes, the State Machine sends a Success notification to SNS Topic. If the processing Lambda fails after 3 retries the State Machine fails and a Failure notification is sent to the SNS Topic. The entire stack is created using CloudFormation.
 
 ![Project Bellflower - Design Diagram](https://subhamay-projects-repository-us-east-1.s3.amazonaws.com/0038-bellflower/bellflower-architecture-diagram.png?)
 
@@ -22,7 +22,7 @@ This is demonstration of a State Machine with Lambda, SNS, SQS and S3. The proce
 
 ### Installing
 
-* Clone the repository.
+* Clone the repository https://github.com/subhamay-cloudworks/0038-bellflower-cft
 * Create a S3 bucket to store the CloudFormation nested stack templates and the Lambda code zip files.
 * Create the folders - bellflower/cft/nested-stacks, bellflower/cft/cross-stacks, bellflower/code/python, bellflower/cft/state-machine
 * Upload the following YAML templates to bellflower/cft/nested-stacks
@@ -34,14 +34,13 @@ This is demonstration of a State Machine with Lambda, SNS, SQS and S3. The proce
     * cloudwatch-stack.yaml
 * Upload the following YAML templates to bellflower/cft/cross-stacks
     * custom-resource-lambda-stack.yaml
-* Upload the following YAML templates to bellflower/cft/
-    * bellflower-root-stack.yaml
 * Zip and Upload the following Python files  to bellflower/code/python
     * processing_lambda.py (processing_lambda.zip)
     * integration_lambda.py (integration_lambda.zip)
-* Upload the ASL file state-machine.asl.json to bellflower/cft-state-machine
-* Create the cross-stack using the template custom-resource-lambda-stack.yaml by using the S3 url and pass the appropriate parameters.
-* Create the entire using by using the root stack template custom-resource-lambda-stack.yaml by providing the required parameters and the s3 cross stack name created in the previous step.
+* Upload the ASL file state-machine.asl.json to bellflower/cft/state-machine
+* Create the cross-stack using the template custom-resource-lambda-stack.yaml by using the S3 url and pass the appropriate parameters and note the cross stack name.
+* Create the entire stack by using the root stack template bellflower/cft/bellflower-root-stack.yaml and providing the required parameters and the s3 cross stack name created in the previous step.
+
 
 ### Executing program
 

--- a/cft/bellflower-root-stack.yaml
+++ b/cft/bellflower-root-stack.yaml
@@ -10,7 +10,10 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Project Bellflower
   Modification History:
-    - 1.0.0  - June 19, 2022   -- Initial Version 
+    - 1.0.0   - June 19, 2023           -- Initial Version 
+    - 1.0.1   - June 21, 2023           -- Changed the resource id from BellflowerReportResultsSNSTopic -> BellflowerSNSTopic
+                                        -- Passing the fully qualified resource names to the nexted stacks instead of the base names.
+
   Resources: 
 
   - A SQS Queue
@@ -76,18 +79,20 @@ Metadata:
     - Label:
         default: "S3 Configuration:"
       Parameters:
-      - S3IntegrationBucketName
+      - S3BucketBaseName
       - S3DataBucketFolder
       - S3BucketBlockPublicAcls
       - S3BucketBlockPublicPolicy
       - S3BucketIgnorePublicAcls
       - S3BucketRestrictPublicBuckets
+    #################################### Step Function #############################################
     - Label:
         default: "Step Function Configuration:"
       Parameters:
       - StepFunctionExecutionRoleName
       - StepFunctionExecutionPolicyName
-      - StepFunctionName
+      - StepFunctionBaseName
+    #################################### Cross Stack Name ##########################################
     - Label: 
         default: "Cross Stack for Custom Resource:"
       Parameters: 
@@ -153,7 +158,7 @@ Metadata:
       SNSSubscriptionEmail:
         default: "Result Notification SQS Subscription Email."
       ################################## S3 Bucket #################################################
-      S3IntegrationBucketName:
+      S3BucketBaseName:
         default: "S3 Bucket Base Name."
       S3DataBucketFolder:
         default: "The folder(s) to be created."
@@ -166,10 +171,13 @@ Metadata:
       S3BucketRestrictPublicBuckets:
         default: "Allow restrictPublicBuckets"
       ################################## Step Function #############################################
+      StepFunctionBaseName:
+        default: "Step Function base name."
       StepFunctionExecutionRoleName:
         default: "Step Function Role Name."
       StepFunctionExecutionPolicyName:
         default: "Step Function Policy Name."
+      ################################## Cross Stack Name ##########################################
       S3CustomResourceStackName:
         default: "Cross Stack Name for Custo Resource."
 Parameters:
@@ -373,7 +381,7 @@ Parameters:
     AllowedPattern: "^[A-Z][a-zA-Z0-9 .,]*$"
     ConstraintDescription: The length should be between 30 and 300, must contain only lowercase letters,space( ) and dot(.) and should start with an uppercase letter.
   ###################################### S3 Bucket #################################################
-  S3IntegrationBucketName:
+  S3BucketBaseName:
     Default: "integration-bucket"
     Description: "The Bucket base name of the S3 Bucket to be used for integration - the region and environment will be added as suffix by the template."
     Type: String
@@ -427,7 +435,7 @@ Parameters:
     MaxLength: 50
     AllowedPattern: "[a-zA-Z-]*"
     ConstraintDescription: The length should be between 5 and 50, must contain only lowercase letters,numbers and hyphen (-).
-  StepFunctionName:
+  StepFunctionBaseName:
     Default: state-machine
     Description: Step Function base name.
     Type: String
@@ -616,7 +624,7 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        S3BucketBaseName: !Sub '${ProjectName}-${S3IntegrationBucketName}'
+        S3BucketName: !Sub '${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
         S3DataBucketFolder: !Ref S3DataBucketFolder
         S3BucketBlockPublicAcls: !Ref S3BucketBlockPublicAcls
         S3BucketBlockPublicPolicy: !Ref S3BucketBlockPublicPolicy
@@ -635,17 +643,17 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        ProcessingLambdaFunctionName: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}'
-        IntegrationLambdaFunctionName: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}'
+        ProcessingLambdaFunctionName: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-${Environment}-${AWS::Region}'
+        IntegrationLambdaFunctionName: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-${Environment}-${AWS::Region}'
         LambdaExecutionRoleName: !Sub '${ProjectName}-${LambdaExecutionRoleName}'
         LambdaExecutionPolicyName: !Sub '${ProjectName}-${LambdaExecutionPolicyName}'
         StepFunctionExecutionRoleName: !Sub '${ProjectName}-${StepFunctionExecutionRoleName}'
         StepFunctionExecutionPolicyName: !Sub '${ProjectName}-${StepFunctionExecutionPolicyName}'
-        SQSQueueBaseName: !Sub '${ProjectName}-${SQSQueueBaseName}'
-        SNSTopicBaseName: !Sub '${ProjectName}-${SNSTopicBaseName}'
-        S3IntegrationBucketName: !Sub '${ProjectName}-${S3IntegrationBucketName}-${AWS::AccountId}'
+        SQSQueueName: !Sub '${ProjectName}-${SQSQueueBaseName}-${Environment}-${AWS::Region}'
+        SNSTopicName: !Sub '${ProjectName}-${SNSTopicBaseName}-${Environment}-${AWS::Region}'
+        S3BucketName: !Sub '${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
         KmsMasterKeyId: !Ref KmsMasterKeyId
-        StepFunctionName: !Sub '${ProjectName}-${StepFunctionName}'
+        StepFunctionName: !Sub '${ProjectName}-${StepFunctionBaseName}-${Environment}-${AWS::Region}'
       TimeoutInMinutes: 15
   ###################################### SQS Queue #################################################
   BellflowerSQSQueue:
@@ -657,7 +665,7 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        SQSQueueBaseName: !Sub '${ProjectName}-${SQSQueueBaseName}'
+        SQSQueueName: !Sub '${ProjectName}-${SQSQueueBaseName}-${Environment}-${AWS::Region}'
         DelaySeconds: !Ref DelaySeconds
         MaximumMessageSize: !Ref MaximumMessageSize
         MessageRetentionPeriod: !Ref MessageRetentionPeriod
@@ -666,7 +674,7 @@ Resources:
         KmsMasterKeyAlias: !Ref KmsMasterKeyAlias
       TimeoutInMinutes: 15
   ###################################### SNS Topic with Subscription ###############################
-  BellflowerReportResultsSNSTopic:
+  BellflowerSNSTopic:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Type: AWS::CloudFormation::Stack
@@ -675,7 +683,7 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        SNSTopicBaseName: !Sub '${ProjectName}-${SNSTopicBaseName}'
+        SNSTopicName: !Sub '${ProjectName}-${SNSTopicBaseName}-${Environment}-${AWS::Region}'
         SNSTopicDisplayName: !Ref SNSTopicDisplayName
         SNSSubscriptionEmail: !Ref SNSSubscriptionEmail
         KmsMasterKeyAlias: !Ref KmsMasterKeyAlias
@@ -690,16 +698,16 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        LambdaExecutionRoleArn: !GetAtt BellflowerIAMRole.Outputs.BellflowerLambdaExecutionRoleArn
+        LambdaExecutionRoleArn: !GetAtt BellflowerIAMRole.Outputs.LambdaExecutionRoleArn
         LambdaHandlerPath: !Join ['.', ['processing_lambda', !Select [1, !Split ['.', !Ref LambdaHandlerPath]]]]
         LambdaRuntime: !Ref LambdaRuntime
         LambdaFunctionTimeoutSecs: !Ref LambdaFunctionTimeoutSecs
         LambdaFunctionMemory: !Ref LambdaFunctionMemory 
         LambdaFunctionCodeBucket: !Ref LambdaFunctionCodeBucket
         LambdaFunctionCodeKey: !Ref ProcessingLambdaFunctionCodeKey
-        LambdaFunctionName: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}'
+        LambdaFunctionName: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-${Environment}-${AWS::Region}'
         LambdaFunctionDescription: !Ref ProcessingLambdaFunctionDescription
-        S3IntegrationBucketName: !Ref S3IntegrationBucketName
+        S3BucketName: !Sub '${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
       TimeoutInMinutes: 15
   ###################################### Integration Lambda Function ###################################################
   BellflowerIntegrationLambdaFunction:
@@ -711,16 +719,16 @@ Resources:
       Parameters:  
         ProjectName: !Ref ProjectName
         Environment: !Ref Environment
-        LambdaExecutionRoleArn: !GetAtt BellflowerIAMRole.Outputs.BellflowerLambdaExecutionRoleArn
+        LambdaExecutionRoleArn: !GetAtt BellflowerIAMRole.Outputs.LambdaExecutionRoleArn
         LambdaHandlerPath: !Join ['.', ['integration_lambda', !Select [1, !Split ['.', !Ref LambdaHandlerPath]]]]
         LambdaRuntime: !Ref LambdaRuntime
         LambdaFunctionTimeoutSecs: !Ref LambdaFunctionTimeoutSecs
         LambdaFunctionMemory: !Ref LambdaFunctionMemory 
         LambdaFunctionCodeBucket: !Ref LambdaFunctionCodeBucket
         LambdaFunctionCodeKey: !Ref IntegrationLambdaFunctionCodeKey
-        LambdaFunctionName: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}'
+        LambdaFunctionName: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-${Environment}-${AWS::Region}'
         LambdaFunctionDescription: !Ref IntegrationLambdaFunctionDescription
-        S3IntegrationBucketName: !Ref S3IntegrationBucketName
+        S3BucketName: !Sub '${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
       TimeoutInMinutes: 15
   BellflowerLambdaInvokePermission:
     Type: AWS::Lambda::Permission
@@ -728,7 +736,7 @@ Resources:
       Action: 'lambda:InvokeFunction'
       FunctionName: !GetAtt BellflowerIntegrationLambdaFunction.Outputs.LambdaFunctionArn
       Principal: s3.amazonaws.com
-      SourceArn: !Sub 'arn:${AWS::Partition}:s3:::${ProjectName}-${S3IntegrationBucketName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
+      SourceArn: !Sub 'arn:${AWS::Partition}:s3:::${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
       SourceAccount: !Ref AWS::AccountId
   BellflowerLambdaTrigger:
     Type: 'Custom::LambdaTrigger'
@@ -737,7 +745,7 @@ Resources:
       ServiceToken: 
         Fn::ImportValue: !Sub '${S3CustomResourceStackName}-S3NoticationCustomResourceLambdaFunctionArn'
       LambdaArn: !GetAtt BellflowerIntegrationLambdaFunction.Outputs.LambdaFunctionArn
-      Bucket: !Sub '${ProjectName}-${S3IntegrationBucketName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
+      Bucket: !Sub '${ProjectName}-${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
       NotificationEventName: 'bellflower-s3-event-notification'
       Prefix: 'inbound'
       Suffix: '.json'
@@ -753,7 +761,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties: 
       KmsKeyId: !Ref KmsMasterKeyId
-      LogGroupName: !Sub '/aws/states/${ProjectName}-${StepFunctionName}-${Environment}-${AWS::Region}'
+      LogGroupName: !Sub '/aws/states/${ProjectName}-${StepFunctionBaseName}-${Environment}-${AWS::Region}'
       RetentionInDays: 14
       Tags: 
       - Key: ProjectName
@@ -763,7 +771,7 @@ Resources:
   BellflowerStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub '${ProjectName}-${StepFunctionName}-${Environment}-${AWS::Region}'
+      StateMachineName: !Sub '${ProjectName}-${StepFunctionBaseName}-${Environment}-${AWS::Region}'
       LoggingConfiguration:
         Level: ALL
         IncludeExecutionData: True
@@ -776,8 +784,8 @@ Resources:
       DefinitionSubstitutions:
         ProcessingLambda: !GetAtt BellflowerProcessingLambdaFunction.Outputs.LambdaFunctionArn
         WaitForResponseQueueURL: !GetAtt BellflowerSQSQueue.Outputs.SQSQueueURL
-        ReportResultSNSTopicArn: !GetAtt BellflowerReportResultsSNSTopic.Outputs.SNSTopicArn
-      RoleArn: !GetAtt BellflowerIAMRole.Outputs.BellflowerStepFunctionExecutionRoleArn
+        SNSTopicArn: !GetAtt BellflowerSNSTopic.Outputs.SNSTopicArn
+      RoleArn: !GetAtt BellflowerIAMRole.Outputs.StepFunctionExecutionRoleArn
       Tags: 
         - Key: ProjectName
           Value: !Ref ProjectName
@@ -797,31 +805,31 @@ Resources:
         Environment: !Ref Environment
         LambdaFunctionName: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-${Environment}-${AWS::Region}'
         SNSTopicName: !Sub '${ProjectName}-${SNSTopicBaseName}-${Environment}-${AWS::Region}'
-        AlarmNameLambdaInvocations: !Sub '${ProcessingLambdaFunctionName}-invocations-alarm'
+        AlarmNameLambdaInvocations: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-invocations-alarm'
         AlarmThresholdLambdaInvocations: !Ref AlarmThresholdLambdaInvocations
         AlarmPeriodInSecondsLambdaInvocations: !Ref AlarmPeriodInSecondsLambdaInvocations
         DatapointsToAlarmLambdaInvocations: !Ref DatapointsToAlarmLambdaInvocations
         EvaluationPeriodsForLambdaInvocations: !Ref EvaluationPeriodsForLambdaInvocations
         AlarmComparisonOperatorLambdaInvocations: !Ref AlarmComparisonOperatorLambdaInvocations
-        AlarmNameLambdaErrors: !Sub '${ProcessingLambdaFunctionName}-errors-alarm'
+        AlarmNameLambdaErrors: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-errors-alarm'
         AlarmThresholdLambdaErrors: !Ref AlarmThresholdLambdaErrors
         AlarmPeriodInSecondsLambdaErrors: !Ref AlarmPeriodInSecondsLambdaErrors
         DatapointsToAlarmLambdaErrors: !Ref DatapointsToAlarmLambdaErrors
         EvaluationPeriodsForLambdaErrors: !Ref EvaluationPeriodsForLambdaErrors
         AlarmComparisonOperatorLambdaErrors: !Ref AlarmComparisonOperatorLambdaErrors
-        AlarmNameLambdaThrottles: !Sub '${ProcessingLambdaFunctionName}-throttles-alarm'
+        AlarmNameLambdaThrottles: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-throttles-alarm'
         AlarmThresholdLambdaThrottles: !Ref AlarmThresholdLambdaThrottles
         AlarmPeriodInSecondsLambdaThrottles: !Ref AlarmPeriodInSecondsLambdaThrottles
         DatapointsToAlarmLambdaThrottles: !Ref DatapointsToAlarmLambdaThrottles
         EvaluationPeriodsForLambdaThrottles: !Ref EvaluationPeriodsForLambdaThrottles
         AlarmComparisonOperatorLambdaThrottles: !Ref AlarmComparisonOperatorLambdaThrottles
-        AlarmNameLambdaDuration: !Sub '${ProcessingLambdaFunctionName}-duration-alarm'
+        AlarmNameLambdaDuration: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-duration-alarm'
         AlarmThresholdLambdaDuration: !Ref AlarmThresholdLambdaDuration
         AlarmPeriodInSecondsLambdaDuration: !Ref AlarmPeriodInSecondsLambdaDuration
         DatapointsToAlarmLambdaDuration: !Ref DatapointsToAlarmLambdaDuration
         EvaluationPeriodsForLambdaDuration: !Ref EvaluationPeriodsForLambdaDuration
         AlarmComparisonOperatorLambdaDuration: !Ref AlarmComparisonOperatorLambdaDuration
-        AlarmNameLambdaConcurrentExecutions: !Sub '${ProcessingLambdaFunctionName}-conc-exec-alarm'
+        AlarmNameLambdaConcurrentExecutions: !Sub '${ProjectName}-${ProcessingLambdaFunctionName}-conc-exec-alarm'
         AlarmThresholdLambdaConcurrentExecutions: !Ref AlarmThresholdLambdaConcurrentExecutions
         AlarmPeriodInSecondsLambdaConcurrentExecutions: !Ref AlarmPeriodInSecondsLambdaConcurrentExecutions
         DatapointsToAlarmLambdaConcurrentExecutions: !Ref DatapointsToAlarmLambdaConcurrentExecutions
@@ -842,31 +850,31 @@ Resources:
         Environment: !Ref Environment
         LambdaFunctionName: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-${Environment}-${AWS::Region}'
         SNSTopicName: !Sub '${ProjectName}-${SNSTopicBaseName}-${Environment}-${AWS::Region}'
-        AlarmNameLambdaInvocations: !Sub '${IntegrationLambdaFunctionName}-invocations-alarm'
+        AlarmNameLambdaInvocations: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-invocations-alarm'
         AlarmThresholdLambdaInvocations: !Ref AlarmThresholdLambdaInvocations
         AlarmPeriodInSecondsLambdaInvocations: !Ref AlarmPeriodInSecondsLambdaInvocations
         DatapointsToAlarmLambdaInvocations: !Ref DatapointsToAlarmLambdaInvocations
         EvaluationPeriodsForLambdaInvocations: !Ref EvaluationPeriodsForLambdaInvocations
         AlarmComparisonOperatorLambdaInvocations: !Ref AlarmComparisonOperatorLambdaInvocations
-        AlarmNameLambdaErrors: !Sub '${IntegrationLambdaFunctionName}-errors-alarm'
+        AlarmNameLambdaErrors: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-errors-alarm'
         AlarmThresholdLambdaErrors: !Ref AlarmThresholdLambdaErrors
         AlarmPeriodInSecondsLambdaErrors: !Ref AlarmPeriodInSecondsLambdaErrors
         DatapointsToAlarmLambdaErrors: !Ref DatapointsToAlarmLambdaErrors
         EvaluationPeriodsForLambdaErrors: !Ref EvaluationPeriodsForLambdaErrors
         AlarmComparisonOperatorLambdaErrors: !Ref AlarmComparisonOperatorLambdaErrors
-        AlarmNameLambdaThrottles: !Sub '${IntegrationLambdaFunctionName}-throttles-alarm'
+        AlarmNameLambdaThrottles: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-throttles-alarm'
         AlarmThresholdLambdaThrottles: !Ref AlarmThresholdLambdaThrottles
         AlarmPeriodInSecondsLambdaThrottles: !Ref AlarmPeriodInSecondsLambdaThrottles
         DatapointsToAlarmLambdaThrottles: !Ref DatapointsToAlarmLambdaThrottles
         EvaluationPeriodsForLambdaThrottles: !Ref EvaluationPeriodsForLambdaThrottles
         AlarmComparisonOperatorLambdaThrottles: !Ref AlarmComparisonOperatorLambdaThrottles
-        AlarmNameLambdaDuration: !Sub '${IntegrationLambdaFunctionName}-duration-alarm'
+        AlarmNameLambdaDuration: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-duration-alarm'
         AlarmThresholdLambdaDuration: !Ref AlarmThresholdLambdaDuration
         AlarmPeriodInSecondsLambdaDuration: !Ref AlarmPeriodInSecondsLambdaDuration
         DatapointsToAlarmLambdaDuration: !Ref DatapointsToAlarmLambdaDuration
         EvaluationPeriodsForLambdaDuration: !Ref EvaluationPeriodsForLambdaDuration
         AlarmComparisonOperatorLambdaDuration: !Ref AlarmComparisonOperatorLambdaDuration
-        AlarmNameLambdaConcurrentExecutions: !Sub '${IntegrationLambdaFunctionName}-conc-exec-alarm'
+        AlarmNameLambdaConcurrentExecutions: !Sub '${ProjectName}-${IntegrationLambdaFunctionName}-conc-exec-alarm'
         AlarmThresholdLambdaConcurrentExecutions: !Ref AlarmThresholdLambdaConcurrentExecutions
         AlarmPeriodInSecondsLambdaConcurrentExecutions: !Ref AlarmPeriodInSecondsLambdaConcurrentExecutions
         DatapointsToAlarmLambdaConcurrentExecutions: !Ref DatapointsToAlarmLambdaConcurrentExecutions
@@ -876,25 +884,25 @@ Resources:
 Outputs:
   BellflowerS3BucketArn:
     Description: Bellflower S3 Bucket Arn
-    Value: !GetAtt BellflowerS3Bucket.Outputs.S3IntegrationBucketArn
+    Value: !GetAtt BellflowerS3Bucket.Outputs.S3BucketArn
   BellflowerLambdaFunctionExecutionRoleArn:
     Description: Bellflower Lambda Execution Role Arn
-    Value: !GetAtt BellflowerIAMRole.Outputs.BellflowerLambdaExecutionRoleArn
+    Value: !GetAtt BellflowerIAMRole.Outputs.LambdaExecutionRoleArn
   BellflowerStepFunctionExecutionRoleArn:
     Description: Bellflower Step Function Execution Role Arn.
-    Value: !GetAtt BellflowerIAMRole.Outputs.BellflowerStepFunctionExecutionRoleArn
+    Value: !GetAtt BellflowerIAMRole.Outputs.StepFunctionExecutionRoleArn
   BellflowerSQSQueueArn:
     Description: SQS Queue Arn
     Value: !GetAtt BellflowerSQSQueue.Outputs.SQSQueueArn
   BellflowerSQSQueueURL:
     Description: SQS Queue URL
     Value: !GetAtt BellflowerSQSQueue.Outputs.SQSQueueURL
-  BellflowerReportResultsSNSTopicArn:
+  BellflowerSNSTopicArn:
     Description: Report Result SNS Topic Arn
-    Value: !GetAtt BellflowerReportResultsSNSTopic.Outputs.SNSTopicArn
+    Value: !GetAtt BellflowerSNSTopic.Outputs.SNSTopicArn
   BellflowerSNSSubscriptionArn:
     Description: SNS Subscription Arn
-    Value: !GetAtt BellflowerReportResultsSNSTopic.Outputs.SNSSubscriptionArn
+    Value: !GetAtt BellflowerSNSTopic.Outputs.SNSSubscriptionArn
   BellflowerProcessingLambdaFunctionArn:
     Description: The Processing Lambda Function Arn
     Value: !GetAtt BellflowerProcessingLambdaFunction.Outputs.LambdaFunctionArn

--- a/cft/nested-stacks/cloudwatch-stack.yaml
+++ b/cft/nested-stacks/cloudwatch-stack.yaml
@@ -9,7 +9,8 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Tarius
   Modification History:
-    - 1.0.0  - June 19, 2023   -- Initial Version 
+    - 1.0.0   - June 19, 2023   -- Initial Version 
+    - 1.0.1   - June 21, 2023   -- Added the project name as prefix to the CloudWatch Alarm names.
   Resources: 
     - Five CloudWatch Alarms For Lambda Fucntion.
   StepsToTest: |
@@ -405,8 +406,8 @@ Resources:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub '${AlarmNameLambdaInvocations}-${Environment}-${AWS::Region}'
-      AlarmDescription: !Sub "${ProjectName} - alarm for number lambda function invocations" 
+      AlarmName: !Ref AlarmNameLambdaInvocations
+      AlarmDescription: !Sub "${ProjectName} - ${Environment} alarm for number lambda function invocations" 
       AlarmActions:
         - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       ComparisonOperator: !Ref AlarmComparisonOperatorLambdaInvocations
@@ -426,8 +427,8 @@ Resources:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub '${AlarmNameLambdaErrors}-${Environment}-${AWS::Region}'
-      AlarmDescription: !Sub "${ProjectName} - alarm for number lambda function errors" 
+      AlarmName: !Ref AlarmNameLambdaErrors
+      AlarmDescription: !Sub "${ProjectName} - ${Environment} alarm for number lambda function errors" 
       AlarmActions:
         - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       ComparisonOperator: !Ref AlarmComparisonOperatorLambdaErrors
@@ -447,8 +448,8 @@ Resources:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub '${AlarmNameLambdaThrottles}-${Environment}-${AWS::Region}'
-      AlarmDescription: !Sub "${ProjectName} - alarm for lambda function throttles" 
+      AlarmName: !Ref AlarmNameLambdaThrottles
+      AlarmDescription: !Sub "${ProjectName} - ${Environment} alarm for lambda function throttles" 
       AlarmActions: 
         - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       ComparisonOperator: !Ref AlarmComparisonOperatorLambdaThrottles
@@ -468,8 +469,8 @@ Resources:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub '${AlarmNameLambdaDuration}-${Environment}-${AWS::Region}'
-      AlarmDescription: !Sub "${ProjectName} - alarm for lambda function duration" 
+      AlarmName: !Ref AlarmNameLambdaDuration
+      AlarmDescription: !Sub "${ProjectName} - ${Environment} alarm for lambda function duration" 
       AlarmActions:
         - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       ComparisonOperator: !Ref AlarmComparisonOperatorLambdaDuration
@@ -489,8 +490,8 @@ Resources:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub '${AlarmNameLambdaConcurrentExecutions}-${Environment}-${AWS::Region}'
-      AlarmDescription: !Sub "${ProjectName} - alarm for lambda concurrent executions" 
+      AlarmName: !Ref AlarmNameLambdaConcurrentExecutions
+      AlarmDescription: !Sub "${ProjectName} - ${Environment} alarm for lambda concurrent executions" 
       AlarmActions:
         - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       ComparisonOperator: !Ref AlarmComparisonOperatorLambdaConcurrentExecutions

--- a/cft/nested-stacks/iam-role-stack.yaml
+++ b/cft/nested-stacks/iam-role-stack.yaml
@@ -9,7 +9,9 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Nested Stack Standardization
   Modification History:
-    - 1.0.0  - June 19, 2023   -- Initial Version 
+    - 1.0.0   - June 19, 2023           -- Initial Version 
+    - 1.0.1   - June 21,2023            -- Changed the parameter SNSTopicBaseName to SNSTopicName to pass the SNS Topic Name.
+                                        -- Changed the parameter SQSQueueBaseName to SQSQueueName to pass the SQS Name.
   Resources: 
     - IAM Role
   StepsToTest: |
@@ -40,9 +42,9 @@ Metadata:
       - LambdaExecutionPolicyName
       - StepFunctionExecutionRoleName
       - StepFunctionExecutionPolicyName
-      - SQSQueueBaseName
-      - SNSTopicBaseName
-      - S3IntegrationBucketName
+      - SQSQueueName
+      - SNSTopicName
+      - S3BucketName
     ParameterLabels:
       ################################## Project Name and Environment ##############################
       ProjectName:
@@ -62,11 +64,11 @@ Metadata:
         default: "Step Function Execution Role Name."
       StepFunctionExecutionPolicyName: 
         default: "Step Function Execution Policy Name."
-      SQSQueueBaseName:  
+      SQSQueueName:  
         default: "The Base Name Of The SQS Queue."
-      SNSTopicBaseName: 
+      SNSTopicName: 
         default: "The Name Of The SNS Topic to publish success / failure message."
-      S3IntegrationBucketName: 
+      S3BucketName: 
         default: "The Name Of The S3 Integration Bucket."
       StepFunctionName: 
         default: "The Name Of The Step Function"
@@ -144,7 +146,7 @@ Parameters:
     MaxLength: 60
     AllowedPattern: "[a-zA-Z0-9-]*"
     ConstraintDescription: The length should be between 20 and 60, must contain only alphanumeric or dash.
-  SQSQueueBaseName:
+  SQSQueueName:
     Default: some-sqs-queue-name
     Type: String
     Description: "SQS Queue Name."
@@ -152,7 +154,7 @@ Parameters:
     MaxLength: 40
     AllowedPattern: "[a-zA-Z0-9/-]*"
     ConstraintDescription: The length should be between 10 and 40, must contain only alphanumeric character.
-  SNSTopicBaseName: 
+  SNSTopicName: 
     Default: some-sns-topic-name
     Type: String
     Description: "SQS Queue Name."
@@ -160,7 +162,7 @@ Parameters:
     MaxLength: 40
     AllowedPattern: "[a-zA-Z0-9/-]*"
     ConstraintDescription: The length should be between 10 and 40, must contain only alphanumeric character.
-  S3IntegrationBucketName: 
+  S3BucketName: 
     Default: some-s3-bucket-name
     Description: "The S3 Bucket Base Name for the source data, the instance and region will be added as suffix by the template."
     Type: String
@@ -172,10 +174,10 @@ Parameters:
     Default: step-function-name
     Description: Step Function Execution Policy Name
     Type: String
-    MinLength: 5
-    MaxLength: 50
-    AllowedPattern: "[a-zA-Z-]*"
-    ConstraintDescription: The length should be between 5 and 50, must contain only lowecase letters, numbers and hyphen (-).
+    MinLength: 10
+    MaxLength: 60
+    AllowedPattern: "[a-zA-Z0-9-]*"
+    ConstraintDescription: The length should be between 5 and 60, must contain only lowecase letters, numbers and hyphen (-).
 Resources:
 
   ###################################### Lambda Execution Role #####################################
@@ -204,15 +206,15 @@ Resources:
                 - 'logs:CreateLogStream'
                 - 'logs:PutLogEvents'
               Resource: 
-                - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProcessingLambdaFunctionName}-${Environment}-${AWS::Region}:*'
-                - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${IntegrationLambdaFunctionName}-${Environment}-${AWS::Region}:*'
+                - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProcessingLambdaFunctionName}:*'
+                - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${IntegrationLambdaFunctionName}:*'
             - Sid: AllowReceiveAndDeleteMessageFromSQS
               Effect: Allow
               Action: 
                 - 'sqs:ReceiveMessage'
                 - 'sqs:DeleteMessage'
                 - 'sqs:GetQueueAttributes'
-              Resource: !Sub 'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${SQSQueueBaseName}-${Environment}-${AWS::Region}'
+              Resource: !Sub 'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${SQSQueueName}'
             - Sid: AllowKMSDecrypt
               Effect: Allow
               Action: 
@@ -220,22 +222,23 @@ Resources:
                 - kms:GenerateDataKey
                 - kms:GenerateDataKeyPair
               Resource: !Ref KmsMasterKeyId
-            - Sid: AllowWriteToS3OutboundFolder
+            - Sid: AllowReadWriteOnS3Bucket
               Effect: Allow
               Action: 
                 - s3:PutObject
                 - s3:GetObject
-              Resource: !Sub 'arn:${AWS::Partition}:s3:::${S3IntegrationBucketName}-${Environment}-${AWS::Region}/outbound/*'
+                - s3:PutObject
+              Resource: !Sub 'arn:${AWS::Partition}:s3:::${S3BucketName}/outbound/*'
             - Sid: AllowReadFromS3InboundFolder
               Effect: Allow
               Action: 
                 - s3:ReadObject
-              Resource: !Sub 'arn:${AWS::Partition}:s3:::${S3IntegrationBucketName}-${Environment}-${AWS::Region}/inbound/*'
+              Resource: !Sub 'arn:${AWS::Partition}:s3:::${S3BucketName}/inbound/*'
             - Sid: AllowSendTaskStatus
               Effect: Allow
               Action: 
                 - states:SendTaskSuccess
-              Resource: !Sub 'arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}-${Environment}-${AWS::Region}'
+              Resource: !Sub 'arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}'
       Tags: 
         - Key: ProjectName
           Value: !Ref ProjectName
@@ -266,7 +269,7 @@ Resources:
               Effect: Allow
               Action: 
                 - sqs:SendMessage
-              Resource: !Sub 'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${SQSQueueBaseName}-${Environment}-${AWS::Region}'
+              Resource: !Sub 'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${SQSQueueName}'
             - Sid: AllowKMSDecrypt
               Effect: Allow
               Action: 
@@ -292,16 +295,16 @@ Resources:
               Effect: Allow
               Action: 
               - sns:Publish
-              Resource: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicBaseName}-${Environment}-${AWS::Region}'
+              Resource: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}'
       Tags:
         - Key: ProjectName
           Value: !Ref ProjectName
         - Key: Environment
           Value: !Ref Environment
 Outputs:
-  BellflowerLambdaExecutionRoleArn:
+  LambdaExecutionRoleArn:
     Description: The Arn of the Lambda Execution Role
     Value: !GetAtt BellflowerLambdaExecutionRole.Arn
-  BellflowerStepFunctionExecutionRoleArn:
+  StepFunctionExecutionRoleArn:
     Description: The Arn of the Step Function Execution Role
     Value: !GetAtt BellflowerStepFunctionExecutionRole.Arn

--- a/cft/nested-stacks/lambda-function-stack.yaml
+++ b/cft/nested-stacks/lambda-function-stack.yaml
@@ -9,7 +9,8 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Nested Stack Standardization
   Modification History:
-    - 1.0.0  - June 19, 2023   -- Initial Version 
+    - 1.0.0   - June 19, 2023           -- Initial Version
+    - 1.0.1   - June 21, 2023           -- Changed the parameter LambdaFunctionName to paaccept ss the fully qualified Lambda Function name from the root stack.
   Resources: 
     - Lambda Function
   StepsToTest: |
@@ -62,7 +63,7 @@ Metadata:
         default: "Name of the Lambda Function."
       LambdaFunctionDescription:
         default: "Lambda Function Description."
-      S3IntegrationBucketName: 
+      S3BucketName: 
         default: "Inregration S3 Bucket Name"
 Parameters:
   ########################################### Project Name and Environment #######################
@@ -134,13 +135,13 @@ Parameters:
     AllowedPattern: "[a-zA-Z0-9-/_.]*"
     ConstraintDescription: "The length should be between 10 and 100, must contain only lowercase letter,numbers,dash, dot, underscore"
   LambdaFunctionName:
-    Default: processing-lambda
+    Default: processing-lambda-devl-us-east-1
     Description: Lambda Function Name
     Type: String
     MinLength: 15
     MaxLength: 50
-    AllowedPattern: "[a-z-]*"
-    ConstraintDescription: The length should be between 15 and 50, must contain only lowercase letters and dash(-) and should start with a letter.
+    AllowedPattern: "[a-z0-9-]*"
+    ConstraintDescription: The length should be between 15 and 50, must contain only lowercase letters,numbers and dash(-) and should start with a letter.
   LambdaFunctionDescription:
     Default: The Processing Lambda Function.
     Description: The Lambda Function Description
@@ -149,7 +150,7 @@ Parameters:
     MaxLength: 200
     AllowedPattern: "^[A-Z][a-zA-Z0-9 .,]*$"
     ConstraintDescription: The length should be between 30 and 300, must contain only lowercase letters,space( ) and dot(.) and should start with an uppercase letter.
-  S3IntegrationBucketName:
+  S3BucketName:
     Default: some-s3-bucket-name
     Description: "The Bucket Base Name of the S3 bucket used for integration,the region will be added as suffix by the template."
     Type: String
@@ -163,7 +164,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: !Ref LambdaRuntime
-      FunctionName: !Sub  '${LambdaFunctionName}-${Environment}-${AWS::Region}'
+      FunctionName: !Ref LambdaFunctionName
       Description: !Ref LambdaFunctionDescription
       Role: !Ref LambdaExecutionRoleArn
       Handler: !Ref LambdaHandlerPath
@@ -177,7 +178,7 @@ Resources:
         Mode: Active
       Environment:
         Variables:
-          S3_BUCKET_NAME: !Sub '${ProjectName}-${S3IntegrationBucketName}-${AWS::AccountId}-${Environment}-${AWS::Region}'
+          S3_BUCKET_NAME: !Ref S3BucketName
       Tags: 
         - Key: ProjectName
           Value: !Ref ProjectName

--- a/cft/nested-stacks/s3-stack.yaml
+++ b/cft/nested-stacks/s3-stack.yaml
@@ -9,7 +9,8 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Nested Stack Standardization
   Modification History:
-    - 1.0.0  - December 10, 2022   -- Initial Version 
+    - 1.0.0   - December 10, 2022       -- Initial Version 
+    - 1.0.1   - June 21,2023            -- Changed the parameter S3BucketBaseName to S3BucketName to pass the fully qualified S3 Bucket name.
   Resources: 
     - S3 Bucket
   StepsToTest: |
@@ -31,7 +32,7 @@ Metadata:
     - Label:
         default: "S3 Configuration:"
       Parameters:
-      - S3BucketBaseName
+      - S3BucketName
       - S3DataBucketFolder
       - S3BucketBlockPublicAcls
       - S3BucketBlockPublicPolicy
@@ -47,8 +48,8 @@ Metadata:
       KmsMasterKeyAlias: 
         default: "The KMS Master Key Alias To Be Used For Server Side Encryption."
       ################################## S3 Bucket and Folder ######################################
-      S3BucketBaseName:
-        default: "S3 Bucket Base Name."
+      S3BucketName:
+        default: "S3 Bucket Name."
       S3DataBucketFolder:
         default: "The folder(s) to be created."
       S3BucketBlockPublicAcls:
@@ -85,12 +86,12 @@ Parameters:
     AllowedPattern: "[a-zA-Z0-9-]*"
     ConstraintDescription: "The length of the KMS Key Alias should be beteen 5 and 20 and can only contain lowercase alphanumeric characters and dash."
   ###################################### S3 Bucket and Folder ######################################
-  S3BucketBaseName:
-    Default: some-s3-bucket-name
-    Description: "The S3 Bucket Base Name For The Source Data, The Region Will Be Added As Suffix By The Template."
+  S3BucketName:
+    Default: "some-s3-bucket-name-devl-us-east-1"
+    Description: "The S3 bucket name for the source data."
     Type: String
     MinLength: 3
-    MaxLength: 40
+    MaxLength: 63
     AllowedPattern: "[a-z][a-z0-9-.]*"
     ConstraintDescription: "The length should be between 3 and 40, must contain only lowercase letter,numbers,dash, dot and should start with a letter."
   S3DataBucketFolder:
@@ -124,10 +125,10 @@ Parameters:
     Type: String
 Resources:
   ###################################### S3 Bucket #################################################
-  S3IntegrationBucket:
+  S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "${S3BucketBaseName}-${AWS::AccountId}-${Environment}-${AWS::Region}"
+      BucketName: !Ref S3BucketName
       BucketEncryption:
           ServerSideEncryptionConfiguration: 
           - BucketKeyEnabled: True
@@ -149,9 +150,9 @@ Resources:
     Properties:
       ServiceToken: 
         Fn::ImportValue: !Sub '${S3CustomResourceStackName}-S3CreateFolderCustomResourceLambdaFunctionArn' 
-      bucket_name: !Ref S3IntegrationBucket
+      bucket_name: !Ref S3Bucket
       folders_to_create: !Ref S3DataBucketFolder
 Outputs:
-  S3IntegrationBucketArn:
+  S3BucketArn:
     Description: The endpoint of the S3 integration bucket.
-    Value: !GetAtt S3IntegrationBucket.Arn
+    Value: !GetAtt S3Bucket.Arn

--- a/cft/nested-stacks/sns-stack.yaml
+++ b/cft/nested-stacks/sns-stack.yaml
@@ -9,7 +9,8 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Nested Stack Standardization
   Modification History:
-    - 1.0.0  - December 10, 2022   -- Initial Version 
+    - 1.0.0   - December 10, 2022       -- Initial Version 
+    - 1.0.1   - June 21,2023            -- Changed the parameter SNSTopicBaseName to SNSTopicName to pass the fully qualified SNS Topic Name.
   Resources: 
     - SNS Topic with SQS Queue subscription
   StepsToTest: |
@@ -31,7 +32,7 @@ Metadata:
     - Label: 
         default: "SNS Configuration:"
       Parameters: 
-        - SNSTopicBaseName
+        - SNSTopicName
         - SNSTopicDisplayName
         - SNSSubscriptionEmail
     ParameterLabels:
@@ -39,7 +40,7 @@ Metadata:
         default: "The Project Name."
       Environment:
         default: "Environment Name."
-      SNSTopicBaseName:
+      SNSTopicName:
         default: "The SNS Topic Name."
       SNSTopicDisplayName:
         default: "The SNS Topic Display Name."
@@ -71,14 +72,14 @@ Parameters:
     AllowedPattern: "[a-zA-Z0-9-]*"
     ConstraintDescription: "The length of the KMS Key Alias should be beteen 5 and 20 and can only contain lowercase alphanumeric characters and dash."
   ###################################### SNS #######################################################
-  SNSTopicBaseName:
-    Default: "sns-topic-name"
+  SNSTopicName:
+    Default: "sns-topic-name-devl-us-east-1"
     Description: "The Base Name Of The Sns Topic."
     Type: String
-    MinLength: 8
-    MaxLength: 40
+    MinLength: 20
+    MaxLength: 100
     AllowedPattern: "[a-zA-Z0-9-]*"
-    ConstraintDescription: The SNS Topic name should be between 8 and 40, must contain only alphanumeric character and dash (-).
+    ConstraintDescription: The SNS Topic name should be between 20 and 100, must contain only alphanumeric character and dash (-).
   SNSTopicDisplayName:
     Default: "SNS Topic Name For Sending Notification"
     Description: "The SNS Topic Display Name."
@@ -101,7 +102,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties: 
       DisplayName: !Ref SNSTopicDisplayName
-      TopicName: !Sub '${SNSTopicBaseName}-${Environment}-${AWS::Region}'
+      TopicName: !Ref SNSTopicName
       KmsMasterKeyId: !Sub 'alias/${KmsMasterKeyAlias}'
       Tags:
         - Key: ProjectName

--- a/cft/nested-stacks/sqs-stack.yaml
+++ b/cft/nested-stacks/sqs-stack.yaml
@@ -9,7 +9,8 @@ Metadata:
   Owner: Subhamay Bhattacharyya
   ProjectName: Nested Stack Standardization
   Modification History:
-    - 1.0.0  - June 19, 2023   -- Initial Version 
+    - 1.0.0   - June 19, 2023           -- Initial Version 
+    - 1.0.1   - June 21,2023            -- Changed the parameter SQSQueueBaseName to SQSQueueName to pass the fully qualified SNS Queue Name.
   Resources: 
     - SQS Standard Queue
   StepsToTest: |
@@ -34,7 +35,7 @@ Metadata:
     - Label: 
         default: "SQS Configuration"
       Parameters: 
-        - SQSQueueBaseName
+        - SQSQueueName
         - DelaySeconds
         - MaximumMessageSize
         - MessageRetentionPeriod
@@ -50,7 +51,7 @@ Metadata:
       KmsMasterKeyAlias: 
         default: "The KMS Master Key Alias To Be Used For Server Side Encryption."
       ################################## SNS #######################################################
-      SQSQueueBaseName:
+      SQSQueueName:
         default: "The SQS Queue Name."
       DelaySeconds:
         default: "Delay Seconds."
@@ -88,12 +89,12 @@ Parameters:
     AllowedPattern: "[a-zA-Z0-9-]*"
     ConstraintDescription: "The length of the KMS Key Alias should be beteen 5 and 20 and can only contain lowercase alphanumeric characters and dash."
   ###################################### SQS #######################################################
-  SQSQueueBaseName:
-    Default: "sqs-queue-name"
+  SQSQueueName:
+    Default: "sqs-queue-name-devl-us-east-1"
     Description: "The Base Name Of The SQS Queue."
     Type: String
-    MinLength: 8
-    MaxLength: 40
+    MinLength: 20
+    MaxLength: 100
     AllowedPattern: "[a-zA-Z0-9-]*"
     ConstraintDescription: The SQS Queue name should be between 8 and 40, must contain only alphanumeric character and dash (-).
   DelaySeconds:
@@ -136,7 +137,7 @@ Resources:
       DelaySeconds: !Ref DelaySeconds
       MaximumMessageSize: !Ref MaximumMessageSize
       MessageRetentionPeriod: !Ref MessageRetentionPeriod
-      QueueName: !Sub '${SQSQueueBaseName}-${Environment}-${AWS::Region}'
+      QueueName: !Ref SQSQueueName
       ReceiveMessageWaitTimeSeconds: !Ref ReceiveMessageWaitTimeSeconds
       KmsMasterKeyId: !Sub 'alias/${KmsMasterKeyAlias}'
       Tags: 

--- a/cft/state-machine/state-machine.asl.json
+++ b/cft/state-machine/state-machine.asl.json
@@ -38,7 +38,7 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "Message.$": "$",
-        "TopicArn": "${ReportResultSNSTopicArn}"
+        "TopicArn": "${SNSTopicArn}"
       },
       "Next": "Fail"
     },
@@ -63,7 +63,7 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "Message.$": "$",
-        "TopicArn": "${ReportResultSNSTopicArn}"
+        "TopicArn": "${SNSTopicArn}"
       },
       "Next": "Success"
     },


### PR DESCRIPTION
Fixed minor type errors
Added project name as prefix to all the AWS resources. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name. Changed the base name to accept the fully qualified resource name.